### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/nibblerybit/3b730eca-81cb-4be4-b311-0f3d20783338/ae5a1929-5681-4645-adba-e8abac193f5c/_apis/work/boardbadge/954bbbdd-d6f4-4737-8e5e-2434bb26499d)](https://dev.azure.com/nibblerybit/3b730eca-81cb-4be4-b311-0f3d20783338/_boards/board/t/ae5a1929-5681-4645-adba-e8abac193f5c/Microsoft.RequirementCategory)
 # TaskCongregation
 For Task assigment in Congregation


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/nibblerybit/3b730eca-81cb-4be4-b311-0f3d20783338/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.